### PR TITLE
openvpn: don't IFF_UP the new tun interface

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -878,8 +878,8 @@ function openvpn_reconfigure($mode, $settings) {
 		/* rename the device */
 		mwexec("/sbin/ifconfig " . escapeshellarg($tunname) . " name " . escapeshellarg($devname));
 
-		/* add the device to the openvpn group and make sure it's UP*/
-		mwexec("/sbin/ifconfig " . escapeshellarg($devname) . " group openvpn up");
+		/* add the device to the openvpn group */
+		mwexec("/sbin/ifconfig " . escapeshellarg($devname) . " group openvpn");
 
 		$ifname = convert_real_interface_to_friendly_interface_name($devname);
 		$grouptmp = link_interface_to_group($ifname);


### PR DESCRIPTION
New openvpn versions set TUNSIFMODE, which FreeBSD's if_tuntap only allows on interfaces which are not up.

So, don't up the tap interface when we create it. Leave that to openvpn itself.

Redmine: #13602

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review